### PR TITLE
Fix panic reported in #3

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -68,7 +68,7 @@ impl<'a> Cpu<'a> {
             addr: 0,
             store: false,
             step: 0,
-            done: false,
+            done: commands.len() == 0,
             commands,
         }
     }
@@ -78,7 +78,7 @@ impl<'a> Cpu<'a> {
         self.addr = 0;
         self.store = false;
         self.step = 0;
-        self.done = false;
+        self.done = self.commands.len() == 0;
     }
 
     pub fn step(&mut self) {


### PR DESCRIPTION
Prevents the CPU from ever being in a state where `done` is `false` but `step` references past the last entry in `commands`.

Currently, stepping the debugger forwards on an empty program causes a panic (#3)